### PR TITLE
fix: changed the stream type and the Readme typo

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -11,7 +11,7 @@ from app import __version__
 
 def download_video(url):
     video = pytube.YouTube(url)
-    stream = video.streams.get_by_itag(18)
+    stream = video.streams.get_by_itag(160)
     stream.download()
     return stream.default_filename
 
@@ -79,12 +79,12 @@ def write_to_file(result, url, title, date):
     meta_data = '---\n' \
                 f'title: {file_title} ' + '\n' \
                 f'transcript_by: youtube_to_bitcoin_transcript_v_{__version__}\n' \
-                f'media: {url}\n' 
+                f'media: {url}\n'
     if date:
-        meta_data = meta_data + f'date: {date}\n' 
+        meta_data = meta_data + f'date: {date}\n'
 
     meta_data = meta_data + '---\n'
-    
+
     with open(file_name_with_ext, 'a') as opf:
         opf.write(meta_data + '\n')
         opf.write(transcribed_text + '\n')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("Readme.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 with open("requirements.txt", "r", encoding="utf-8") as fh:
     requirements = fh.read()


### PR DESCRIPTION
This PR fixes the typo in the setup.py where readme was spelled as README instead of Readme. This also changes the stream type to 160 (video mp4 144p).